### PR TITLE
fix: Key normalization inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,17 +431,22 @@ type Config struct {
 
 ### Field Naming
 
-Use idiomatic Go names and override the key mapping when needed:
+Use idiomatic Go names - keys are automatically normalized:
 
 ```go
 type Config struct {
-    MaxConnections int    `conf:"name:maxconnections"`
-    APIKey         string `conf:"name:apikey"`
-    RetryTimeout   time.Duration `conf:"name:retry.timeout"`
+    MaxConnections int           // Matches: maxconnections
+    APIKey         string         // Matches: apikey
+    RetryTimeout   time.Duration  // Matches: retrytimeout
 }
 ```
 
-**Key normalization**: Field names are lowercased (first letter only) by default. Use `name:` tag to specify exact key paths for configuration sources.
+**Key normalization**: All keys are fully lowercased for matching. Field name `MaxConnections` automatically matches config key `maxconnections`, `MAXCONNECTIONS`, or `max_connections` (after normalization). Use `name:` tag only when you need a different key path:
+
+```go
+type Config struct {
+    MaxConnections int `conf:"name:max.connections"` // Matches: max.connections
+}
 
 ### Handling Secrets
 

--- a/binding.go
+++ b/binding.go
@@ -519,33 +519,32 @@ func bindStruct(target reflect.Value, data map[string]mergedEntry, provenanceFie
 
 // determineKeyPath determines the configuration key path for a field.
 // Priority: name tag > prefix + derived > derived
+// All keys are normalized to lowercase for consistent matching.
 func determineKeyPath(fieldName string, tagCfg tagConfig, parentPrefix string) string {
 	// If name tag is specified, use it directly (ignores prefix)
 	if tagCfg.name != "" {
-		return tagCfg.name
+		return strings.ToLower(tagCfg.name)
 	}
 
-	// Derive key from field name (lowercase first letter)
+	// Derive key from field name (fully lowercase)
 	derived := deriveFieldKey(fieldName)
 
-	// Apply parent prefix if present
+	// Apply parent prefix if present (normalize prefix too)
 	if parentPrefix != "" {
-		return parentPrefix + "." + derived
+		return strings.ToLower(parentPrefix) + "." + derived
 	}
 
 	return derived
 }
 
 // deriveFieldKey derives a configuration key from a field name.
-// It lowercases the first letter of the field name.
+// It fully lowercases the field name to match source key normalization.
 func deriveFieldKey(fieldName string) string {
 	if fieldName == "" {
 		return ""
 	}
 
-	runes := []rune(fieldName)
-	runes[0] = rune(strings.ToLower(string(runes[0]))[0])
-	return string(runes)
+	return strings.ToLower(fieldName)
 }
 
 // isOptionalType checks if a type is an Optional[T] type.

--- a/binding_normalization_test.go
+++ b/binding_normalization_test.go
@@ -1,0 +1,170 @@
+package rigging
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestBindStruct_FieldNameNormalization tests that multi-word field names
+// are properly normalized to match lowercase configuration keys.
+func TestBindStruct_FieldNameNormalization(t *testing.T) {
+	tests := []struct {
+		name      string
+		fieldName string
+		configKey string
+		value     string
+	}{
+		{
+			name:      "APIKey matches apikey",
+			fieldName: "APIKey",
+			configKey: "apikey",
+			value:     "secret123",
+		},
+		{
+			name:      "MaxConnections matches maxconnections",
+			fieldName: "MaxConnections",
+			configKey: "maxconnections",
+			value:     "100",
+		},
+		{
+			name:      "RetryTimeout matches retrytimeout",
+			fieldName: "RetryTimeout",
+			configKey: "retrytimeout",
+			value:     "30s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a struct type dynamically for each test case
+			// For simplicity, we'll test with predefined struct types
+		})
+	}
+}
+
+// TestBindStruct_MultiWordFields tests binding with actual multi-word field names.
+func TestBindStruct_MultiWordFields(t *testing.T) {
+	type Config struct {
+		APIKey         string
+		MaxConnections int
+		RetryTimeout   string
+	}
+
+	data := map[string]mergedEntry{
+		"apikey":         {value: "secret123", sourceName: "env"},
+		"maxconnections": {value: "100", sourceName: "file"},
+		"retrytimeout":   {value: "30s", sourceName: "default"},
+	}
+
+	var cfg Config
+	var provFields []FieldProvenance
+	errors := bindStruct(reflect.ValueOf(&cfg), data, &provFields, "", "")
+
+	if len(errors) > 0 {
+		t.Fatalf("unexpected errors: %v", errors)
+	}
+
+	if cfg.APIKey != "secret123" {
+		t.Errorf("APIKey = %q, want %q", cfg.APIKey, "secret123")
+	}
+	if cfg.MaxConnections != 100 {
+		t.Errorf("MaxConnections = %d, want %d", cfg.MaxConnections, 100)
+	}
+	if cfg.RetryTimeout != "30s" {
+		t.Errorf("RetryTimeout = %q, want %q", cfg.RetryTimeout, "30s")
+	}
+
+	// Verify provenance
+	if len(provFields) != 3 {
+		t.Fatalf("provenance fields = %d, want 3", len(provFields))
+	}
+}
+
+// TestBindStruct_PrefixNormalization tests that prefix tags are normalized.
+func TestBindStruct_PrefixNormalization(t *testing.T) {
+	type DatabaseConfig struct {
+		Host string
+		Port int
+	}
+
+	type Config struct {
+		Database DatabaseConfig `conf:"prefix:DATABASE"` // Uppercase prefix
+	}
+
+	data := map[string]mergedEntry{
+		"database.host": {value: "localhost", sourceName: "file"},
+		"database.port": {value: "5432", sourceName: "file"},
+	}
+
+	var cfg Config
+	var provFields []FieldProvenance
+	errors := bindStruct(reflect.ValueOf(&cfg), data, &provFields, "", "")
+
+	if len(errors) > 0 {
+		t.Fatalf("unexpected errors: %v", errors)
+	}
+
+	if cfg.Database.Host != "localhost" {
+		t.Errorf("Database.Host = %q, want %q", cfg.Database.Host, "localhost")
+	}
+	if cfg.Database.Port != 5432 {
+		t.Errorf("Database.Port = %d, want %d", cfg.Database.Port, 5432)
+	}
+}
+
+// TestBindStruct_CustomNameNormalization tests that name tags are normalized.
+func TestBindStruct_CustomNameNormalization(t *testing.T) {
+	type Config struct {
+		APIKey string `conf:"name:API.KEY"` // Uppercase in tag
+	}
+
+	data := map[string]mergedEntry{
+		"api.key": {value: "secret123", sourceName: "env"},
+	}
+
+	var cfg Config
+	var provFields []FieldProvenance
+	errors := bindStruct(reflect.ValueOf(&cfg), data, &provFields, "", "")
+
+	if len(errors) > 0 {
+		t.Fatalf("unexpected errors: %v", errors)
+	}
+
+	if cfg.APIKey != "secret123" {
+		t.Errorf("APIKey = %q, want %q", cfg.APIKey, "secret123")
+	}
+
+	// Verify provenance uses normalized key
+	if len(provFields) != 1 {
+		t.Fatalf("provenance fields = %d, want 1", len(provFields))
+	}
+	if provFields[0].KeyPath != "api.key" {
+		t.Errorf("KeyPath = %q, want %q", provFields[0].KeyPath, "api.key")
+	}
+}
+
+// TestDeriveFieldKey tests the field key derivation function.
+func TestDeriveFieldKey(t *testing.T) {
+	tests := []struct {
+		fieldName string
+		want      string
+	}{
+		{"Host", "host"},
+		{"Port", "port"},
+		{"APIKey", "apikey"},
+		{"MaxConnections", "maxconnections"},
+		{"RetryTimeout", "retrytimeout"},
+		{"HTTPServer", "httpserver"},
+		{"URLPath", "urlpath"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.fieldName, func(t *testing.T) {
+			got := deriveFieldKey(tt.fieldName)
+			if got != tt.want {
+				t.Errorf("deriveFieldKey(%q) = %q, want %q", tt.fieldName, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What
This PR fixes a bug in which inconsistent key normalization caused binding failures:

Before:

Source keys: Fully lowercased (`strings.ToLower(key)`)
Field keys: Only first letter lowercased (`APIKey` → `aPIKey`)
Result: Keys didn't match! `apikey` ≠ `aPIKey`

## Why
- Multi-word field names (APIKey, MaxConnections) wouldn't bind correctly
- Uppercase in prefix: and `name`: `tags` wouldn't match normalized source keys
- Strict mode would incorrectly report unknown keys

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] Performance
- [ ] Breaking change

## Testing

- `TestBindStruct_MultiWordFields`: Tests APIKey, MaxConnections, RetryTimeout
- `TestBindStruct_PrefixNormalization`: Tests uppercase prefix tags
- `TestBindStruct_CustomNameNormalization`: Tests uppercase name tags
- `TestDeriveFieldKey`: Unit tests for key derivation function

```bash
# Commands you ran
go test ./...
```

## Checklist

- [x] Tests pass (`go test ./...`)
- [x] Formatted (`gofmt -s -w .`)
- [x] No vet warnings (`go vet ./...`)
- [x] Coverage maintained (>70%)
- [x] Added tests if needed
- [x] Updated docs if needed

---

**For reviewers:** Does this align with Rigging's philosophy of simplicity and zero dependencies?
