### PR TITLE
fix: debounce closure bug in watch loop

### DIFF
--- a/loader.go
+++ b/loader.go
@@ -354,6 +354,9 @@ func (l *Loader[T]) watchLoop(ctx context.Context, initialCfg *T, snapshotCh cha
 				return
 			}
 
+			// Capture the cause to avoid closure issues with loop variable
+			cause := event.Cause
+
 			// Debounce: reset timer on each event
 			if debounceTimer != nil {
 				debounceTimer.Stop()
@@ -377,7 +380,7 @@ func (l *Loader[T]) watchLoop(ctx context.Context, initialCfg *T, snapshotCh cha
 					Config:   newCfg,
 					Version:  currentVersion,
 					LoadedAt: time.Now(),
-					Source:   event.Cause,
+					Source:   cause,
 				}
 
 				select {


### PR DESCRIPTION
## What
The watch loop's debounce timer was closing over the loop variable event, which could cause race conditions:

```
case event, ok := <-mergedChanges:
    debounceTimer = time.AfterFunc(debounceDelay, func() {
        snapshot := Snapshot[T]{
            Source: event.Cause,  // BUG: closes over loop variable
        }
    })
```

**Issues:**

- `time.AfterFunc` + `Timer.Stop() `don't guarantee older callbacks won't fire if already queued
- If an older timer fires after a newer one, it could use a stale `event.Cause`
- Multiple rapid events could cause the wrong cause to be reported in snapshots

## FIX

We should capture `event.Cause` in a local variable per iteration:

```
case event, ok := <-mergedChanges:
    // Capture the cause to avoid closure issues with loop variable
    cause := event.Cause
    
    debounceTimer = time.AfterFunc(debounceDelay, func() {
        snapshot := Snapshot[T]{
            Source: cause,  // FIXED: closes over local variable
        }
    })
```

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] Performance
- [ ] Breaking change

## Testing

<!-- How did you test this? -->

```bash
# Commands you ran
go test ./...
```

## Checklist

- [ ] Tests pass (`go test ./...`)
- [ ] Formatted (`gofmt -s -w .`)
- [ ] No vet warnings (`go vet ./...`)
- [ ] Coverage maintained (>70%)
- [ ] Added tests if needed
- [ ] Updated docs if needed

---

**For reviewers:** Does this align with Rigging's philosophy of simplicity and zero dependencies?
