### PR TITLE
impelement CaseSensitive option in sourceenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,12 +304,36 @@ All errors are collected and returned together.
 
 ```go
 source := sourceenv.New(sourceenv.Options{
-    Prefix: "APP_",  // Only load APP_* variables
+    Prefix:        "APP_",  // Only load APP_* variables
+    CaseSensitive: false,   // Prefix matching is case-insensitive (default)
 })
 
 // Maps environment variables to struct fields:
 // APP_DATABASE__HOST → Database.Host
 // APP_SERVER__PORT → Server.Port
+```
+
+**Prefix Matching:**
+- By default (`CaseSensitive: false`), prefix matching is case-insensitive
+- `APP_`, `app_`, and `App_` all match when prefix is `"APP_"`
+- Set `CaseSensitive: true` for exact case matching
+- Keys are always normalized to lowercase after prefix stripping
+
+```go
+// Case-insensitive (default) - matches all variations
+sourceenv.New(sourceenv.Options{
+    Prefix:        "APP_",
+    CaseSensitive: false,
+})
+// Matches: APP_HOST, app_host, App_Host
+
+// Case-sensitive - exact match only
+sourceenv.New(sourceenv.Options{
+    Prefix:        "APP_",
+    CaseSensitive: true,
+})
+// Matches: APP_HOST only
+// Ignores: app_host, App_Host
 ```
 
 ### Files (YAML/JSON/TOML)

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -31,6 +31,8 @@ type Config struct {
 **Environment Variables**: Use `__` for nesting
 - `APP_DATABASE__HOST` → `Database.Host`
 - `APP_SERVER__PORT` → `Server.Port`
+- Prefix matching is case-insensitive by default (`APP_`, `app_`, `App_` all match)
+- Set `CaseSensitive: true` in `sourceenv.Options` for exact matching
 
 **YAML Keys**: Match struct fields (lowercase)
 ```yaml


### PR DESCRIPTION
## What

The `CaseSensitive` field in `sourceenv.Options` was defined but not being used.

**Implementation:** Updated `Load()` function to respect the `CaseSensitive` option for prefix matching.
**Backward compatible:** Default behavior (`case-insensitive`) remains unchanged.

## Why

<!-- Why is this change needed? -->

## Type

- [x] Fix
- [x] Feature
- [x] Docs
- [ ] Performance
- [ ] Breaking change

## Testing
- Added unit tests (`TestEnvSource_CaseSensitivePrefix`)
- Added runnable example test (`Example_envCaseSensitive`)

```bash
# Commands you ran
go test ./...
```

## Checklist

- [ ] Tests pass (`go test ./...`)
- [ ] Formatted (`gofmt -s -w .`)
- [ ] No vet warnings (`go vet ./...`)
- [ ] Coverage maintained (>70%)
- [ ] Added tests if needed
- [ ] Updated docs if needed

---

**For reviewers:** Does this align with Rigging's philosophy of simplicity and zero dependencies?
