### PR TITLE
fix: underscore normalization

### DIFF
--- a/internal/normalize/keys.go
+++ b/internal/normalize/keys.go
@@ -6,10 +6,13 @@ import (
 )
 
 // ToLowerDotPath normalizes a key to lowercase dot-separated path.
-// Double underscores (__) → dots, single underscores preserved.
-// Examples: FOO__BAR → foo.bar, DB_MAX → db_max
+// Double underscores (__) → dots, all other underscores stripped.
+// Examples: FOO__BAR → foo.bar, DB_MAX → dbmax, MAX_CONNECTIONS → maxconnections
 func ToLowerDotPath(key string) string {
+	// First convert double underscores to dots
 	normalized := strings.ReplaceAll(key, "__", ".")
+	// Then strip all remaining single underscores
+	normalized = strings.ReplaceAll(normalized, "_", "")
 	return strings.ToLower(normalized)
 }
 

--- a/internal/normalize/keys_test.go
+++ b/internal/normalize/keys_test.go
@@ -16,14 +16,14 @@ func TestToLowerDotPath(t *testing.T) {
 			expected: "foo.bar",
 		},
 		{
-			name:     "single underscore preserved",
+			name:     "single underscore stripped",
 			input:    "DB_MAX_CONNECTIONS",
-			expected: "db_max_connections",
+			expected: "dbmaxconnections",
 		},
 		{
 			name:     "mixed double and single underscores",
 			input:    "API__RATE_LIMIT",
-			expected: "api.rate_limit",
+			expected: "api.ratelimit",
 		},
 		{
 			name:     "multiple levels",
@@ -44,6 +44,16 @@ func TestToLowerDotPath(t *testing.T) {
 			name:     "only underscores",
 			input:    "____",
 			expected: "..",
+		},
+		{
+			name:     "max_connections should match maxconnections",
+			input:    "max_connections",
+			expected: "maxconnections",
+		},
+		{
+			name:     "MAX_CONNECTIONS should match maxconnections",
+			input:    "MAX_CONNECTIONS",
+			expected: "maxconnections",
 		},
 	}
 

--- a/sourceenv/env_test.go
+++ b/sourceenv/env_test.go
@@ -40,15 +40,15 @@ func TestEnvSource_Load(t *testing.T) {
 			},
 		},
 		{
-			name: "single underscore preserved",
+			name: "single underscore stripped",
 			opts: Options{},
 			envVars: map[string]string{
 				"DB_MAX_CONNECTIONS": "100",
 				"API__RATE_LIMIT":    "1000",
 			},
 			expected: map[string]any{
-				"db_max_connections": "100",
-				"api.rate_limit":     "1000",
+				"dbmaxconnections": "100",
+				"api.ratelimit":    "1000",
 			},
 		},
 		{
@@ -240,10 +240,10 @@ func TestEnvSource_EmptyValues(t *testing.T) {
 	}
 
 	// Empty values should still be included
-	if val, ok := result["empty_var"]; !ok {
-		t.Error("expected empty_var to be present")
+	if val, ok := result["emptyvar"]; !ok {
+		t.Error("expected emptyvar to be present")
 	} else if val != "" {
-		t.Errorf("empty_var = %v, want empty string", val)
+		t.Errorf("emptyvar = %v, want empty string", val)
 	}
 }
 


### PR DESCRIPTION
## What
There is a discrepancy between the readme file and the actual behavior in the code regarding the underscore normalization: 

Currently single underscores are preserved, so `max_connections` normalized to `max_connections` (didn't match `maxconnections`)

This PR fix fixes this issue: So single underscores are stripped, so `max_connections` normalizes to `maxconnections`.



## Why

examples (what we expect from the readme): 

- `MAX_CONNECTIONS` -> `maxconnections` (strip underscores, lowercase)
- `max_connections` -> `maxconnections` (strip underscores, lowercase)
- `MAXCONNECTIONS` ->  `maxconnections` (lowercase)

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] Performance
- [ ] Breaking change

## Testing

<!-- How did you test this? -->

```bash
# Commands you ran
go test ./...
```

## Checklist

- [x] Tests pass (`go test ./...`)
- [x] Formatted (`gofmt -s -w .`)
- [x] No vet warnings (`go vet ./...`)
- [x] Coverage maintained (>70%)
- [x] Added tests if needed
- [ ] Updated docs if needed

---

**For reviewers:** Does this align with Rigging's philosophy of simplicity and zero dependencies?
