### PR TITLE
fix:  filtering empty strings, deduplicating values in `oneof` directive

### DIFF
--- a/binding.go
+++ b/binding.go
@@ -3,6 +3,7 @@ package rigging
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -65,11 +66,22 @@ func parseTag(tag string) tagConfig {
 		case "max":
 			cfg.max = value
 		case "oneof":
+			// Empty or duplicated values are ignored.
+			// The final result is sorted.
 			if value != "" {
-				cfg.oneof = strings.Split(value, ",")
-				for i := range cfg.oneof {
-					cfg.oneof[i] = strings.TrimSpace(cfg.oneof[i])
+				parts := strings.Split(value, ",")
+				seen := make(map[string]bool)
+				for _, v := range parts {
+					trimmed := strings.TrimSpace(v)
+					if trimmed == "" || seen[trimmed] {
+						continue
+					}
+
+					cfg.oneof = append(cfg.oneof, trimmed)
+					seen[trimmed] = true
 				}
+
+				sort.Strings(cfg.oneof)
 			}
 		case "required":
 			// No value or explicit "true" means true

--- a/binding_test.go
+++ b/binding_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func TestParseTag(t *testing.T) {
+func TestBinding_ParseTag(t *testing.T) {
 	tests := []struct {
 		name     string
 		tag      string
@@ -230,14 +230,14 @@ func TestParseTag(t *testing.T) {
 			name: "oneof directive",
 			tag:  "oneof:prod,staging,dev",
 			expected: tagConfig{
-				oneof: []string{"prod", "staging", "dev"},
+				oneof: []string{"dev", "prod", "staging"},
 			},
 		},
 		{
 			name: "oneof with spaces",
 			tag:  "oneof:prod, staging, dev",
 			expected: tagConfig{
-				oneof: []string{"prod", "staging", "dev"},
+				oneof: []string{"dev", "prod", "staging"},
 			},
 		},
 		{
@@ -245,6 +245,13 @@ func TestParseTag(t *testing.T) {
 			tag:  "oneof:prod",
 			expected: tagConfig{
 				oneof: []string{"prod"},
+			},
+		},
+		{
+			name: "oneof with duplicated values",
+			tag:  "oneof:dev,prod,staging,dev,prod",
+			expected: tagConfig{
+				oneof: []string{"dev", "prod", "staging"},
 			},
 		},
 		{
@@ -258,21 +265,21 @@ func TestParseTag(t *testing.T) {
 			name: "oneof with only commas",
 			tag:  "oneof:,,,",
 			expected: tagConfig{
-				oneof: []string{"", "", "", ""},
+				oneof: nil,
 			},
 		},
 		{
 			name: "oneof with trailing comma",
 			tag:  "oneof:a,b,c,",
 			expected: tagConfig{
-				oneof: []string{"a", "b", "c", ""},
+				oneof: []string{"a", "b", "c"},
 			},
 		},
 		{
 			name: "oneof with leading comma",
 			tag:  "oneof:,a,b,c",
 			expected: tagConfig{
-				oneof: []string{"", "a", "b", "c"},
+				oneof: []string{"a", "b", "c"},
 			},
 		},
 		{
@@ -286,7 +293,7 @@ func TestParseTag(t *testing.T) {
 			name: "oneof with special characters",
 			tag:  "oneof:prod-1,staging_2,dev.3",
 			expected: tagConfig{
-				oneof: []string{"prod-1", "staging_2", "dev.3"},
+				oneof: []string{"dev.3", "prod-1", "staging_2"},
 			},
 		},
 		{
@@ -325,7 +332,7 @@ func TestParseTag(t *testing.T) {
 			name: "oneof at end of tag",
 			tag:  "required,secret,oneof:foo,bar,baz",
 			expected: tagConfig{
-				oneof:    []string{"foo", "bar", "baz"},
+				oneof:    []string{"bar", "baz", "foo"},
 				required: true,
 				secret:   true,
 			},
@@ -652,7 +659,7 @@ func TestParseTag(t *testing.T) {
 	}
 }
 
-func TestConvertValue(t *testing.T) {
+func TestBinding_ConvertValue(t *testing.T) {
 	tests := []struct {
 		name        string
 		rawValue    any
@@ -962,7 +969,7 @@ func TestConvertValue(t *testing.T) {
 	}
 }
 
-func TestConvertValue_Optional(t *testing.T) {
+func TestBinding_ConvertValue_Optional(t *testing.T) {
 	// Test Optional[int]
 	t.Run("string to Optional[int]", func(t *testing.T) {
 		targetType := reflect.TypeOf(Optional[int]{})
@@ -1049,7 +1056,7 @@ func TestConvertValue_Optional(t *testing.T) {
 	})
 }
 
-func TestParseBool(t *testing.T) {
+func TestBinding_ParseBool(t *testing.T) {
 	tests := []struct {
 		input   string
 		want    bool
@@ -1096,7 +1103,7 @@ func TestParseBool(t *testing.T) {
 	}
 }
 
-func TestParseStringSlice(t *testing.T) {
+func TestBinding_ParseStringSlice(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   any
@@ -1160,7 +1167,7 @@ func TestParseStringSlice(t *testing.T) {
 	}
 }
 
-func TestDetermineKeyPath(t *testing.T) {
+func TestBinding_DetermineKeyPath(t *testing.T) {
 	tests := []struct {
 		name         string
 		fieldName    string
@@ -1406,7 +1413,7 @@ func TestDetermineKeyPath(t *testing.T) {
 	}
 }
 
-func TestExtractTagDirectives(t *testing.T) {
+func TestBinding_ExtractTagDirectives(t *testing.T) {
 	tests := []struct {
 		name     string
 		tag      string
@@ -1522,7 +1529,7 @@ func TestExtractTagDirectives(t *testing.T) {
 	}
 }
 
-func TestStartsWithDirective(t *testing.T) {
+func TestBinding_StartsWithDirective(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -159,7 +159,7 @@ Configure binding and validation with the `conf` tag:
 | `default:X` | Default value if not provided | `conf:"default:8080"` |
 | `min:N` | Minimum value (numeric) or length (string) | `conf:"min:1024"` |
 | `max:N` | Maximum value (numeric) or length (string) | `conf:"max:65535"` |
-| `oneof:a,b,c` | Value must be one of the options | `conf:"oneof:prod,staging,dev"` |
+| `oneof:a,b,c` | Value must be one of the options (duplicates removed, empty values ignored) | `conf:"oneof:prod,staging,dev"` |
 | `secret` | Mark field for redaction | `conf:"secret"` |
 | `prefix:path` | Prefix for nested struct fields | `conf:"prefix:database"` |
 | `name:path` | Override derived key path | `conf:"name:custom.path"` |

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -17,7 +17,7 @@ type Config struct {
     // Validation constraints
     MaxConns int `conf:"min:1,max:100"`
 
-    // Allowed values
+    // Allowed values (duplicates removed, empty values ignored)
     Environment string `conf:"oneof:prod,staging,dev"`
 
     // Secret (auto-redacted)


### PR DESCRIPTION
## What
Improves `oneof` directive parsing by filtering empty strings, deduplicating values, and sorting results for deterministic output.

**Changes:**
- Empty values are now skipped (e.g., `oneof:,,,` → `nil`)
- Duplicate values are removed (e.g., `oneof:dev,dev,prod` → `["dev", "prod"]`)
- Results are sorted for consistency with negligible performance impact

## Why

<!-- Why is this change needed? -->

## Type

- [x] Fix
- [ ] Feature
- [x] Docs
- [ ] Performance
- [ ] Breaking change

## Testing

<!-- How did you test this? -->

```bash
# Commands you ran
go test ./...
```

## Checklist

- [ ] Tests pass (`go test ./...`)
- [ ] Formatted (`gofmt -s -w .`)
- [ ] No vet warnings (`go vet ./...`)
- [ ] Coverage maintained (>70%)
- [ ] Added tests if needed
- [ ] Updated docs if needed

---

**For reviewers:** Does this align with Rigging's philosophy of simplicity and zero dependencies?
