### PR TITLE
feat: implement snapshot core types

### DIFF
--- a/snapshot.go
+++ b/snapshot.go
@@ -26,6 +26,9 @@ var (
 )
 
 // supportedVersions lists snapshot format versions that can be read.
+// Used by ReadSnapshot in Phase 5.
+//
+//nolint:unused // Will be used by ReadSnapshot implementation
 var supportedVersions = map[string]bool{
 	"1.0": true,
 }

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -288,7 +288,6 @@ func TestFlattenConfig_DeeplyNested(t *testing.T) {
 	}
 }
 
-
 func TestApplyExclusions_ExactPathMatching(t *testing.T) {
 	config := map[string]any{
 		"database.host":     "localhost",


### PR DESCRIPTION
## What

Lays the groundwork for capturing point-in-time configuration state with provenance tracking, enabling users to answer: What is this service actually running with?

- `ConfigSnapshot` struct with Version, Timestamp, Config, Provenance fields
- `SnapshotOption` functional options pattern with WithExcludeFields
- Constants: `MaxSnapshotSize` (100MB), `SnapshotVersion` ("1.0")
- `flattenConfig` helper: walks structs to build dot-notation key map, handles nested structs, `Optional[T]`, `time.Time`, and secret redaction
- `applyExclusions` helper: case-insensitive field path filtering

## Why

Related to `Creating Snapshots`:  https://github.com/Azhovan/rigging/issues/22

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] Performance
- [ ] Breaking change

## Testing

<!-- How did you test this? -->

```bash
# Commands you ran
go test ./...
```

## Checklist

- [x] Tests pass (`go test ./...`)
- [x] Formatted (`gofmt -s -w .`)
- [x] No vet warnings (`go vet ./...`)
- [ ] Coverage maintained (>70%)
- [ ] Added tests if needed
- [ ] Updated docs if needed

---

**For reviewers:** Does this align with Rigging's philosophy of simplicity and zero dependencies?
