### PR TITLE
feat: implement template path expansion

### DIFF
--- a/snapshot.go
+++ b/snapshot.go
@@ -231,6 +231,21 @@ func applyExclusions(config map[string]any, exclude []string) map[string]any {
 	return result
 }
 
+// ExpandPath expands template variables using current time.
+// For consistency with snapshot metadata, prefer WriteSnapshot which
+// uses the snapshot's internal timestamp for expansion.
+func ExpandPath(template string) string {
+	return ExpandPathWithTime(template, time.Now())
+}
+
+// ExpandPathWithTime expands template variables using the provided timestamp.
+// Replaces all {{timestamp}} occurrences with the time formatted as 20060102-150405.
+// Returns the path unchanged if no template variables are present.
+func ExpandPathWithTime(template string, t time.Time) string {
+	timestamp := t.UTC().Format("20060102-150405")
+	return strings.ReplaceAll(template, "{{timestamp}}", timestamp)
+}
+
 // formatFlatValue formats a field value for the flattened config map.
 // Secrets are redacted, other values are returned in their natural types.
 func formatFlatValue(v reflect.Value, prov *FieldProvenance) any {


### PR DESCRIPTION
## What

This PR adds `ExpandPath` and `ExpandPathWithTime` functions for expanding `{{timestamp}}` template variables in snapshot file paths.

- `ExpandPathWithTime(template, time)` - replaces all `{{timestamp}}` with UTC-formatted time (`20060102-150405`)
- `ExpandPath(template)` - convenience wrapper using current time

## Why

Related to Creating Snapshots: https://github.com/Azhovan/rigging/issues/22

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] Performance
- [ ] Breaking change

## Testing

<!-- How did you test this? -->

```bash
# Commands you ran
go test ./...
```

## Checklist

- [ ] Tests pass (`go test ./...`)
- [ ] Formatted (`gofmt -s -w .`)
- [ ] No vet warnings (`go vet ./...`)
- [ ] Coverage maintained (>70%)
- [ ] Added tests if needed
- [ ] Updated docs if needed

---

**For reviewers:** Does this align with Rigging's philosophy of simplicity and zero dependencies?
