### PR TITLE
feat: implement snapshot persistent with atomic writes

### DIFF
--- a/snapshot.go
+++ b/snapshot.go
@@ -277,8 +277,8 @@ func WriteSnapshot(snapshot *ConfigSnapshot, pathTemplate string) error {
 	// Create parent directories with 0700 permissions
 	dir := filepath.Dir(targetPath)
 	if dir != "" && dir != "." {
-		if err := os.MkdirAll(dir, 0700); err != nil {
-			return err
+		if mkdirErr := os.MkdirAll(dir, 0700); mkdirErr != nil {
+			return mkdirErr
 		}
 	}
 
@@ -374,7 +374,6 @@ func formatFlatValue(v reflect.Value, prov *FieldProvenance) any {
 		return v.Interface()
 	}
 }
-
 
 // generateTempFileName generates a unique temporary file name for atomic writes.
 // The temp file is placed in the same directory as the target to ensure

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -1074,7 +1074,6 @@ func TestExpandPathProperties_TimezoneNormalization(t *testing.T) {
 	}
 }
 
-
 // generateTempFileName unit tests
 
 func TestGenerateTempFileName_UniqueNames(t *testing.T) {
@@ -1153,7 +1152,6 @@ func TestGenerateTempFileName_Format(t *testing.T) {
 	}
 }
 
-
 // WriteSnapshot unit tests
 
 func TestWriteSnapshot_WritesValidSnapshot(t *testing.T) {
@@ -1179,7 +1177,7 @@ func TestWriteSnapshot_WritesValidSnapshot(t *testing.T) {
 	}
 
 	// Verify file exists
-	if _, err := os.Stat(targetPath); os.IsNotExist(err) {
+	if _, statErr := os.Stat(targetPath); os.IsNotExist(statErr) {
 		t.Fatal("Snapshot file was not created")
 	}
 
@@ -1220,7 +1218,7 @@ func TestWriteSnapshot_CreatesParentDirectories(t *testing.T) {
 	}
 
 	// Verify file exists
-	if _, err := os.Stat(targetPath); os.IsNotExist(err) {
+	if _, statErr := os.Stat(targetPath); os.IsNotExist(statErr) {
 		t.Fatal("Snapshot file was not created")
 	}
 
@@ -1421,7 +1419,6 @@ func TestWriteSnapshot_OverwritesExistingFile(t *testing.T) {
 	}
 }
 
-
 // Property-based tests for WriteSnapshot
 
 func TestWriteSnapshotProperties_TimestampFilenameConsistency(t *testing.T) {
@@ -1465,7 +1462,7 @@ func TestWriteSnapshotProperties_TimestampFilenameConsistency(t *testing.T) {
 		expectedPath := filepath.Join(testDir, fmt.Sprintf("config-%s.json", expectedTimestamp))
 
 		// Verify the file exists at the expected path
-		if _, err := os.Stat(expectedPath); os.IsNotExist(err) {
+		if _, statErr := os.Stat(expectedPath); os.IsNotExist(statErr) {
 			t.Errorf("Expected file at %s for snapshot time %v, but file does not exist",
 				expectedPath, snapshotTime)
 		}


### PR DESCRIPTION
## What

This PR adds the `WriteSnapshot` function to persist configuration snapshots to disk with atomic write semantics: 

- Added `generateTempFileName` helper using crypto/rand for unique temp file names
- Implemented `WriteSnapshot` with:
  - Template path expansion using snapshot's internal timestamp (not current time)
   - JSON marshaling with indentation
  - Size validation against 100MB limit
  - Parent directory creation (0700 permissions)
  - Atomic write pattern: temp file → chmod 0600 → rename
  - Automatic temp file cleanup on errors

## Why

Related to Creating Snapshots: https://github.com/Azhovan/rigging/issues/22


## Type

- [ ] Fix
- [x] Feature
- [ ] Docs
- [ ] Performance
- [ ] Breaking change

## Testing

<!-- How did you test this? -->

```bash
# Commands you ran
go test ./...
```

## Checklist

- [x] Tests pass (`go test ./...`)
- [x] Formatted (`gofmt -s -w .`)
- [x] No vet warnings (`go vet ./...`)
- [x] Coverage maintained (>70%)
- [ ] Added tests if needed
- [ ] Updated docs if needed

---

**For reviewers:** Does this align with Rigging's philosophy of simplicity and zero dependencies?
