### PR TITLE
fix: env: tag is parsed but not actually used in key resolution/binding

### DIFF
--- a/binding.go
+++ b/binding.go
@@ -590,12 +590,18 @@ func bindScalarField(
 }
 
 // determineKeyPath determines the configuration key path for a field.
-// Priority: name tag > prefix + derived > derived
+// Priority: name tag > env tag > prefix + derived > derived
 // All keys are normalized to lowercase for consistent matching.
 func determineKeyPath(fieldName string, tagCfg tagConfig, parentPrefix string) string {
 	// If the name tag is specified, use it directly (ignores prefix)
 	if tagCfg.name != "" {
 		return strings.ToLower(tagCfg.name)
+	}
+
+	// If the env tag is specified, normalize env var syntax to a key path.
+	// Example: APP__DB__HOST -> app.db.host
+	if tagCfg.env != "" {
+		return normalize.ToLowerDotPath(tagCfg.env)
 	}
 
 	// Derive key from field name (fully lowercase)

--- a/binding_bind_test.go
+++ b/binding_bind_test.go
@@ -240,6 +240,36 @@ func TestBindStruct_CustomName(t *testing.T) {
 	}
 }
 
+func TestBindStruct_EnvTag(t *testing.T) {
+	type Config struct {
+		DBHost string `conf:"env:DB__HOST"`
+	}
+
+	data := map[string]mergedEntry{
+		"db.host": {value: "db.example.com", sourceName: "env"},
+	}
+
+	var cfg Config
+	var provFields []FieldProvenance
+	errors := bindStruct(reflect.ValueOf(&cfg), data, &provFields, "", "")
+
+	if len(errors) > 0 {
+		t.Fatalf("unexpected errors: %v", errors)
+	}
+
+	if cfg.DBHost != "db.example.com" {
+		t.Errorf("DBHost = %q, want %q", cfg.DBHost, "db.example.com")
+	}
+
+	hostProv := findProvenance(provFields, "DBHost")
+	if hostProv == nil {
+		t.Fatal("DBHost provenance not found")
+	}
+	if hostProv.KeyPath != "db.host" {
+		t.Errorf("DBHost key path = %q, want %q", hostProv.KeyPath, "db.host")
+	}
+}
+
 func TestBindStruct_SecretField(t *testing.T) {
 	type Config struct {
 		Password string `conf:"secret"`

--- a/binding_test.go
+++ b/binding_test.go
@@ -1332,6 +1332,34 @@ func TestBinding_DetermineKeyPath(t *testing.T) {
 			parentPrefix: "parent",
 			expected:     "custom_key",
 		},
+		{
+			name:      "env tag maps to normalized env key path",
+			fieldName: "Host",
+			tagCfg: tagConfig{
+				env: "DB__PRIMARY__HOST",
+			},
+			parentPrefix: "",
+			expected:     "db.primary.host",
+		},
+		{
+			name:      "env tag ignores parent prefix",
+			fieldName: "Host",
+			tagCfg: tagConfig{
+				env: "DB__HOST",
+			},
+			parentPrefix: "database",
+			expected:     "db.host",
+		},
+		{
+			name:      "name tag takes precedence over env tag",
+			fieldName: "Host",
+			tagCfg: tagConfig{
+				name: "custom.host",
+				env:  "DB__HOST",
+			},
+			parentPrefix: "",
+			expected:     "custom.host",
+		},
 
 		// Case normalization
 		{


### PR DESCRIPTION
## What

- Fixes `conf:"env:..."` so it is actually used in key resolution during binding.
- Updates key-resolution precedence to `name` > `env` > derived field key (with prefix behavior unchanged for derived keys).
- Adds tests for `env` precedence and end-to-end binding/provenance with `env` tags.

## Why

- `env:` was parsed but previously ignored at bind-time, which made documented behavior misleading and could cause silent misconfiguration.

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] Performance
- [ ] Breaking change

## Testing

```bash
# Commands run
go test ./... -run 'TestBinding_DetermineKeyPath|TestBindStruct_EnvTag'
go test ./...
go vet ./...
go test -race ./...
```

## Checklist

- [x] Tests pass (`go test ./...`)
- [ ] Formatted (`gofmt -s -w .`)
- [x] No vet warnings (`go vet ./...`)
- [ ] Coverage maintained (>70%)
- [x] Added tests if needed
- [x] Updated docs if needed

---

**For reviewers:** Yes. This is a minimal, targeted fix that aligns behavior with existing tags/docs and adds no new dependencies.