### PR TITLE
fix: unrelated struct with that shape can be misclassified

### DIFF
--- a/binding.go
+++ b/binding.go
@@ -27,6 +27,7 @@ type tagConfig struct {
 }
 
 var tagConfigCache sync.Map
+var optionalTypePkgPath = reflect.TypeOf(Optional[int]{}).PkgPath()
 
 func cloneTagConfig(cfg tagConfig) tagConfig {
 	if len(cfg.oneof) == 0 {
@@ -651,6 +652,13 @@ func deriveFieldKey(fieldName string) string {
 // isOptionalType checks if a type is an Optional[T] type.
 func isOptionalType(t reflect.Type) bool {
 	if t.Kind() != reflect.Struct {
+		return false
+	}
+	if t.PkgPath() != optionalTypePkgPath {
+		return false
+	}
+	name := t.Name()
+	if name != "Optional" && !strings.HasPrefix(name, "Optional[") {
 		return false
 	}
 	if t.NumField() != 2 {

--- a/binding_bind_test.go
+++ b/binding_bind_test.go
@@ -370,6 +370,45 @@ func TestBindStruct_OptionalField(t *testing.T) {
 	})
 }
 
+func TestBindStruct_ValueSetLookalikeStructIsNotOptional(t *testing.T) {
+	type ValueSet struct {
+		Value int
+		Set   bool
+	}
+	type Config struct {
+		Flag ValueSet
+	}
+
+	data := map[string]mergedEntry{
+		"flag.value": {value: "42", sourceName: "env"},
+		"flag.set":   {value: "true", sourceName: "env"},
+	}
+
+	var cfg Config
+	var provFields []FieldProvenance
+	errors := bindStruct(reflect.ValueOf(&cfg), data, &provFields, "", "")
+
+	if len(errors) > 0 {
+		t.Fatalf("unexpected errors: %v", errors)
+	}
+
+	if cfg.Flag.Value != 42 {
+		t.Errorf("Flag.Value = %d, want %d", cfg.Flag.Value, 42)
+	}
+	if !cfg.Flag.Set {
+		t.Errorf("Flag.Set = %v, want true", cfg.Flag.Set)
+	}
+
+	valueProv := findProvenance(provFields, "Flag.Value")
+	if valueProv == nil {
+		t.Fatal("Flag.Value provenance not found")
+	}
+	setProv := findProvenance(provFields, "Flag.Set")
+	if setProv == nil {
+		t.Fatal("Flag.Set provenance not found")
+	}
+}
+
 func TestBindStruct_MultipleErrors(t *testing.T) {
 	type Config struct {
 		Host string `conf:"required"`


### PR DESCRIPTION
## What

- Tighten optional detection in `binding.go` so only `rigging.Optional[T]` is treated as optional.
- Add regression coverage in `binding_bind_test.go` to ensure lookalike structs (`Value` + `Set bool`) are handled as normal nested structs.

## Why

Structural detection could misclassify unrelated structs, causing nested fields to be skipped during binding. This fix prevents silent misbinding and keeps optional semantics scoped to the intended type.

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] Performance
- [ ] Breaking change

## Testing

Verified with formatting, targeted regression checks, full test suite, vet, and coverage:

```bash
gofmt -w binding.go binding_bind_test.go
go test ./... -run 'TestBindStruct_ValueSetLookalikeStructIsNotOptional|TestBindStruct_OptionalField|TestBinding_ConvertValue_Optional'
go test ./...
go vet ./...
go test -coverprofile=coverage.out ./... && go tool cover -func=coverage.out | tail -n 1
