### PR TITLE
docs: align API docs with current implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Enforce validation rules at startup. All configuration is validated before your 
 type Config struct {
     Environment string `conf:"required,oneof:prod,staging,dev"`
     Database struct {
+        Host string `conf:"required"`
         Port int `conf:"min:1024,max:65535"`
     } `conf:"prefix:database"`
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -31,11 +31,26 @@ type Source interface {
 }
 ```
 
+`Watch` may return `ErrWatchNotSupported` for sources that don't support runtime change events.
+
 **Built-in sources:**
 - `sourcefile.New(path string, opts sourcefile.Options)` - YAML/JSON/TOML files
 - `sourceenv.New(opts sourceenv.Options)` - Environment variables
 
 `Name()` is used in provenance output (for example, `file:config.yaml`, `env:APP_PORT`).
+
+### SourceWithKeys
+
+Optional interface for richer provenance (original source keys).
+
+```go
+type SourceWithKeys interface {
+    Source
+    LoadWithKeys(ctx context.Context) (data map[string]any, originalKeys map[string]string, err error)
+}
+```
+
+`originalKeys` maps normalized keys back to original source keys (for example, full env var names).
 
 ### Optional[T]
 
@@ -127,6 +142,12 @@ func DumpEffective[T any](w io.Writer, cfg *T, opts ...DumpOption) error
 - `AsJSON()` - Output as JSON instead of text
 - `WithIndent(indent string)` - Set JSON indentation
 
+When `AsJSON()` and `WithSources()` are combined, leaf fields are wrapped as:
+
+```json
+{"value":"...","source":"..."}
+```
+
 **Examples:**
 
 ```go
@@ -189,6 +210,15 @@ err := rigging.WriteSnapshot(snapshot, "snapshots/config-{{timestamp}}.json")
 restored, err := rigging.ReadSnapshot("snapshots/config-20240115-103000.json")
 ```
 
+### Path Helpers
+
+```go
+func ExpandPath(template string) string
+func ExpandPathWithTime(template string, t time.Time) string
+```
+
+`WriteSnapshot` uses the snapshot's internal `Timestamp` when expanding `{{timestamp}}` to keep filename and snapshot metadata consistent.
+
 ### ConfigSnapshot
 
 ```go
@@ -250,6 +280,7 @@ Configure binding and validation with the `conf` tag:
 | Tag | Description | Example |
 |-----|-------------|---------|
 | `required` | Field must have a value | `conf:"required"` |
+| `env:VAR` | Bind from an explicit env-style key path (normalized with `__` -> `.` and lowercased) | `conf:"env:APP__DATABASE__HOST"` |
 | `default:X` | Default value if not provided | `conf:"default:8080"` |
 | `min:N` | Minimum value (numeric) or length (string) | `conf:"min:1024"` |
 | `max:N` | Maximum value (numeric) or length (string) | `conf:"max:65535"` |
@@ -271,9 +302,9 @@ type Config struct {
 **Tag precedence:**
 
 - `name:` overrides all key derivation (ignores `prefix:` and field name)
-- `prefix:` applies to nested struct fields
-- Without `name:`, keys are derived from field names (snake_case)
-- Environment normalization converts `__` to `.` and preserves single `_` (after prefix stripping)
+- `env:` is used when `name:` is not set
+- otherwise keys are derived from field names (snake_case), with parent `prefix:` for nested structs
+- env-style normalization converts `__` to `.` and preserves single `_`
 
 ```go
 type Config struct {
@@ -299,6 +330,10 @@ type Snapshot[T any] struct {
 }
 ```
 
+Watch behavior:
+- `Watch` emits an initial snapshot immediately (`Version=1`, `Source="initial"`).
+- Reloads from source change events are debounced by 100ms.
+
 Provenance note:
 - For configs emitted by `Watch`, `GetProvenance` is intended for the latest snapshot.
 - Older snapshots may no longer have global provenance after subsequent reloads.
@@ -313,6 +348,8 @@ type ChangeEvent struct {
     Cause string    // Description of the change
 }
 ```
+
+`ErrWatchNotSupported` is returned by `Source.Watch` for sources that don't support watch mode.
 
 ## Strict Mode
 

--- a/docs/configuration-sources.md
+++ b/docs/configuration-sources.md
@@ -54,7 +54,8 @@ source := sourcefile.New("config.yaml", sourcefile.Options{
 
 Important:
 - Env source strips the configured prefix first, then preserves single underscores and converts `__` to `.`.
-- File source does not rewrite separators; it flattens and lowercases keys.
+- File source flattens nested objects but does not rewrite separators.
+- Rigging lowercases keys during loader merge for consistent matching across sources.
 - If your file keys are snake_case, use `name:` tags to match them.
 
 ```go
@@ -131,6 +132,10 @@ for snapshots != nil || errors != nil {
     }
 }
 ```
+
+Behavior notes:
+- `Watch` emits an initial snapshot immediately (`Version=1`, `Source="initial"`).
+- Subsequent reloads are debounced for 100ms.
 
 Production notes:
 - Keep a "last good config" in your app and only swap it after successful `applyNewConfig`.


### PR DESCRIPTION
## What

- Fix the README validation example so it compiles by adding the missing `Database.Host` field in `README.md`.
- Update `docs/api-reference.md` to include missing exported API details: `SourceWithKeys`, `ErrWatchNotSupported`, `env:` tag support, and snapshot path helpers (`ExpandPath`, `ExpandPathWithTime`).
- Clarify documented behavior in `docs/api-reference.md` and `docs/configuration-sources.md` for watch semantics (initial snapshot + 100ms debounce), JSON dump shape when combining `AsJSON()` and `WithSources()`, and where key lowercasing occurs.

## Why

- The docs were out of sync with current public APIs and runtime behavior.
- The README contained a non-compiling snippet in the validation section.
- Aligning docs with implementation reduces onboarding friction and integration mistakes.

## Type

- [x] Fix
- [ ] Feature
- [x] Docs
- [ ] Performance
- [ ] Breaking change

## Testing

Executed:

```bash
go test ./...
make ci
```

Results:
- `go test ./...` passed.
- `make ci` passed (format, vet, tests, lint) with reported coverage `81.5%`.

## Checklist

- [x] Tests pass (`go test ./...`)
- [x] Formatted (`gofmt -s -w .`)
- [x] No vet warnings (`go vet ./...`)
- [x] Coverage maintained (>70%)
- [x] Added tests if needed
- [x] Updated docs if needed

Added tests if needed: N/A — docs-only changes; no runtime behavior was modified.

---

**For reviewers:** Does this align with Rigging's philosophy of simplicity and zero dependencies?
