### PR TITLE
Clarify WithTransformerFunc usage in guides and examples

### DIFF
--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -67,10 +67,10 @@ This keeps normalization logic out of request paths and lets tag validation oper
 
 ```go
 loader := rigging.NewLoader[Config]().
-    WithTransformer(rigging.TransformerFunc[Config](func(ctx context.Context, cfg *Config) error {
+    WithTransformerFunc(func(ctx context.Context, cfg *Config) error {
         cfg.Env = strings.ToLower(strings.TrimSpace(cfg.Env))
         return nil
-    }))
+    })
 ```
 
 Typical uses:
@@ -79,6 +79,8 @@ Typical uses:
 - dedupe/sort lists before custom validation or downstream use
 
 Important:
+- `WithTransformerFunc(...)` is the ergonomic helper for inline transform functions.
+- `WithTransformer(...)` registers a reusable `Transformer[T]` implementation.
 - `WithTransformer(...)` is for typed value normalization after binding/defaults/conversion.
 - source key aliasing or key normalization belongs in sources/source wrappers, not typed transforms.
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -135,12 +135,13 @@ Tag validation and custom validators run during `Load`.
 
 Use `WithTransformer(...)` when you need to normalize or derive typed values before tag validation runs.
 This is useful for canonicalization such as trimming whitespace or normalizing enum casing.
+Use `WithTransformerFunc(...)` for inline functions (as shown below), and `WithTransformer(...)` when registering a reusable `Transformer[T]` implementation.
 
 ```go
-loader.WithTransformer(rigging.TransformerFunc[Config](func(ctx context.Context, cfg *Config) error {
+loader.WithTransformerFunc(func(ctx context.Context, cfg *Config) error {
     cfg.Environment = strings.ToLower(strings.TrimSpace(cfg.Environment))
     return nil
-}))
+})
 ```
 
 Use typed transforms for post-bind value normalization.

--- a/example_test.go
+++ b/example_test.go
@@ -136,10 +136,10 @@ func ExampleLoader_WithTransformer() {
 
 	loader := rigging.NewLoader[Config]().
 		WithSource(sourceenv.New(sourceenv.Options{Prefix: "EXTRANS_"})).
-		WithTransformer(rigging.TransformerFunc[Config](func(ctx context.Context, cfg *Config) error {
+		WithTransformerFunc(func(ctx context.Context, cfg *Config) error {
 			cfg.Environment = strings.ToLower(strings.TrimSpace(cfg.Environment))
 			return nil
-		}))
+		})
 
 	cfg, err := loader.Load(context.Background())
 	if err != nil {


### PR DESCRIPTION
## What

Update transformer documentation/examples to consistently show `WithTransformerFunc(...)` for inline transforms, and clarify when to use `WithTransformerFunc(...)` vs `WithTransformer(...)`.

This PR:
- updates the typed-transform example in `docs/quick-start.md` to use `WithTransformerFunc(...)`
- updates the typed-transform example in `docs/patterns.md` to use `WithTransformerFunc(...)`
- adds guide-level wording in `docs/quick-start.md` and `docs/patterns.md` explaining:
  - `WithTransformerFunc(...)` for inline functions
  - `WithTransformer(...)` for reusable `Transformer[T]` implementations
- updates `ExampleLoader_WithTransformer` in `example_test.go` to use `WithTransformerFunc(...)`

Docs decision: updated `docs/quick-start.md` and `docs/patterns.md` in the same PR (plus the GoDoc example in `example_test.go`).

## Why

The repo already added `WithTransformerFunc(...)`, but the main typed-transform guide examples still showed the older inline adapter form (`WithTransformer(TransformerFunc[T](...))`).

This created inconsistency and made the new helper harder to discover in the places users are most likely to copy from (Quick Start, Patterns, and GoDoc examples).

## Type

- [ ] Fix
- [ ] Feature
- [x] Docs
- [ ] Performance
- [ ] Breaking change

## Testing

Executed:

```bash
gofmt -w example_test.go
go test ./...
```

Result:
- `go test ./...` passed (root package tests passed; example packages compiled)

Would run:

```bash
go vet ./...
make ci
```

Reason:
- additional static/CI parity checks; this PR is docs/example-only and does not change runtime behavior

## Checklist

- [x] Tests pass (`go test ./...`)
- [ ] Formatted (`gofmt -s -w .`)
- [ ] No vet warnings (`go vet ./...`)
- [ ] Coverage maintained (>70%)
- [ ] Added tests if needed
- [x] Updated docs if needed

Notes:
- Only `example_test.go` required formatting; ran `gofmt -w example_test.go` (not repo-wide `gofmt -s -w .`)
- No new tests were added because this PR only updates docs/example syntax and explanatory wording (no behavior change)
- Coverage was not measured in this change

---

**For reviewers:** Does this align with Rigging's philosophy of simplicity and zero dependencies?
