### PR TITLE
fix: originalKeys values include the full source path prefix when Options.Root is set,

### DIFF
--- a/sourcefile/file.go
+++ b/sourcefile/file.go
@@ -103,6 +103,11 @@ func (f *fileSource) LoadWithKeys(ctx context.Context) (map[string]any, map[stri
 	flattened := make(map[string]any)
 	originalKeys := make(map[string]string)
 	flattenMapWithKeys("", rootValue, flattened, originalKeys)
+	if f.opts.Root != "" {
+		for key, original := range originalKeys {
+			originalKeys[key] = f.opts.Root + "." + original
+		}
+	}
 
 	return flattened, originalKeys, nil
 }

--- a/sourcefile/file_test.go
+++ b/sourcefile/file_test.go
@@ -205,7 +205,8 @@ root:
 	assert.Equal(t, "5s", data["pollInterval"])
 	assert.NotContains(t, data, "root.section.enabled")
 	assert.NotContains(t, data, "sibling.enabled")
-	assert.Equal(t, "enabled", originalKeys["enabled"])
+	assert.Equal(t, "root.section.enabled", originalKeys["enabled"])
+	assert.Equal(t, "root.section.pollInterval", originalKeys["pollInterval"])
 }
 
 func TestFileSource_Load_RootErrors(t *testing.T) {


### PR DESCRIPTION
Address copilot reviews [here](https://github.com/Azhovan/rigging/pull/48#pullrequestreview-3890056171)