### PR TITLE
feat: Add an opt-in subtree key-shape adaptation path

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -43,6 +43,8 @@ type Source interface {
 - `Format string` - Optional explicit format (`yaml`, `json`, `toml`). When empty, inferred from file extension.
 - `Required bool` - When true, missing files return an error. When false, missing files return an empty map.
 - `Root string` - Optional dot-separated subtree path to load and flatten as the source root.
+- `SnakeCaseKeys bool` - Optional key-shape adaptation. When true, flattened keys are rewritten to underscore snake_case (`pollInterval` -> `poll_interval`, `http.clientTimeout` -> `http_client_timeout`).
+- `KeyPrefix string` - Optional prefix added to each flattened key after optional `SnakeCaseKeys` conversion (`msa_` + `poll_interval` -> `msa_poll_interval`).
 
 `sourcefile.Root` example:
 
@@ -63,6 +65,8 @@ if err != nil {
 }
 _ = cfg
 ```
+
+When `SnakeCaseKeys` is enabled, `root.section.pollInterval` becomes `poll_interval`; with `KeyPrefix: "msa_"`, it becomes `msa_poll_interval`.
 
 `Name()` is used in provenance output (for example, `file:config.yaml`, `env:APP_PORT`).
 

--- a/docs/configuration-sources.md
+++ b/docs/configuration-sources.md
@@ -42,6 +42,8 @@ source := sourcefile.New("config.yaml", sourcefile.Options{
 - Supports YAML/JSON/TOML (extension auto-detected unless `Format` is set)
 - Nested objects are flattened to dot paths (`database.host`)
 - `Root` loads from a dot-separated subtree (for example, `root.section`) and flattens keys relative to that subtree
+- `SnakeCaseKeys` (opt-in) rewrites flattened keys to underscore snake_case (for example, `pollInterval` -> `poll_interval`, `http.clientTimeout` -> `http_client_timeout`)
+- `KeyPrefix` (optional) prepends a prefix to each flattened key after optional `SnakeCaseKeys` conversion (for example, `msa_`)
 - Missing file returns empty map unless `Required: true`
 - `Root` errors are typed: `sourcefile.ErrRootNotFound` (missing path), `sourcefile.ErrRootNotMap` (non-map path), `sourcefile.ErrInvalidRoot` (invalid syntax such as leading/trailing dot, empty segment, wildcard)
 
@@ -72,10 +74,23 @@ With this setup, file keys are flattened relative to `root.section`:
 - `root.section.enabled` -> `enabled`
 - `root.section.pollInterval` -> `pollInterval`
 
+### Optional Subtree Key Adaptation (Opt-In)
+
+```go
+source := sourcefile.New("config.yaml", sourcefile.Options{
+    Root:          "root.section",
+    SnakeCaseKeys: true,
+    KeyPrefix:     "msa_",
+})
+```
+
+With `SnakeCaseKeys: true` and `KeyPrefix: "msa_"`:
+- `root.section.pollInterval` -> `msa_poll_interval`
+
 Notes:
 - `Root` uses dot-separated path segments only.
 - `Required` behavior is unchanged; if the file is missing and `Required` is false, load returns an empty map.
-- `Root` is applied inside `sourcefile` before flattening; source ordering/precedence across providers is unchanged.
+- `Root` is applied inside `sourcefile` before flattening, and key adaptation is disabled by default.
 
 ### Nested Collections from File Sources
 
@@ -133,6 +148,7 @@ Behavior notes:
 Important:
 - Env source strips the configured prefix first, then preserves single underscores and converts `__` to `.`.
 - File source flattens nested objects but does not rewrite separators.
+- File source can optionally adapt flattened keys via `SnakeCaseKeys` and `KeyPrefix` in `sourcefile.Options`.
 - Rigging lowercases keys during loader merge for consistent matching across sources.
 - If your file keys are snake_case, use `name:` tags to match them.
 

--- a/sourcefile/file.go
+++ b/sourcefile/file.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Azhovan/rigging"
+	"github.com/Azhovan/rigging/internal/normalize"
 	"github.com/pelletier/go-toml/v2"
 	"gopkg.in/yaml.v3"
 )
@@ -25,6 +26,15 @@ type Options struct {
 	// Root selects a dot-separated map path inside the parsed file (for example, "root.section").
 	// When set, only that subtree is flattened and exposed as the source root.
 	Root string
+
+	// SnakeCaseKeys converts flattened keys to underscore-separated snake_case.
+	// Examples: "pollInterval" -> "poll_interval", "http.clientTimeout" -> "http_client_timeout".
+	// Disabled by default.
+	SnakeCaseKeys bool
+
+	// KeyPrefix prepends a prefix to each flattened key after optional SnakeCaseKeys conversion.
+	// Example: prefix "msa_" + "poll_interval" -> "msa_poll_interval".
+	KeyPrefix string
 }
 
 var (
@@ -108,8 +118,47 @@ func (f *fileSource) LoadWithKeys(ctx context.Context) (map[string]any, map[stri
 			originalKeys[key] = f.opts.Root + "." + original
 		}
 	}
+	if f.opts.SnakeCaseKeys || f.opts.KeyPrefix != "" {
+		adapted, adaptedOriginal, adaptErr := adaptFlattenedKeys(flattened, originalKeys, f.opts)
+		if adaptErr != nil {
+			return nil, nil, adaptErr
+		}
+		flattened = adapted
+		originalKeys = adaptedOriginal
+	}
 
 	return flattened, originalKeys, nil
+}
+
+func adaptFlattenedKeys(flattened map[string]any, originalKeys map[string]string, opts Options) (map[string]any, map[string]string, error) {
+	adapted := make(map[string]any, len(flattened))
+	adaptedOriginalKeys := make(map[string]string, len(originalKeys))
+
+	for key, value := range flattened {
+		adaptedKey := adaptKeyShape(key, opts)
+		if _, exists := adapted[adaptedKey]; exists {
+			return nil, nil, fmt.Errorf("sourcefile: adapted key collision for %q", adaptedKey)
+		}
+		adapted[adaptedKey] = value
+		adaptedOriginalKeys[adaptedKey] = originalKeys[key]
+	}
+
+	return adapted, adaptedOriginalKeys, nil
+}
+
+func adaptKeyShape(key string, opts Options) string {
+	adaptedKey := key
+	if opts.SnakeCaseKeys {
+		segments := strings.Split(adaptedKey, ".")
+		for i, segment := range segments {
+			segments[i] = normalize.DeriveFieldPath(segment)
+		}
+		adaptedKey = strings.Join(segments, "_")
+	}
+	if opts.KeyPrefix != "" {
+		adaptedKey = opts.KeyPrefix + adaptedKey
+	}
+	return adaptedKey
 }
 
 func resolveRoot(raw map[string]any, root string, path string) (any, error) {

--- a/sourcefile/file_test.go
+++ b/sourcefile/file_test.go
@@ -188,6 +188,8 @@ root:
   section:
     enabled: true
     pollInterval: 5s
+    nestedConfig:
+      retryCount: 3
   sibling:
     enabled: false
 `
@@ -203,10 +205,69 @@ root:
 
 	assert.Equal(t, true, data["enabled"])
 	assert.Equal(t, "5s", data["pollInterval"])
+	assert.Equal(t, 3, data["nestedConfig.retryCount"])
 	assert.NotContains(t, data, "root.section.enabled")
 	assert.NotContains(t, data, "sibling.enabled")
 	assert.Equal(t, "root.section.enabled", originalKeys["enabled"])
 	assert.Equal(t, "root.section.pollInterval", originalKeys["pollInterval"])
+	assert.Equal(t, "root.section.nestedConfig.retryCount", originalKeys["nestedConfig.retryCount"])
+}
+
+func TestFileSource_Load_Root_KeyAdaptation(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "config.yaml")
+	yamlContent := `
+root:
+  section:
+    pollInterval: 5s
+    nestedConfig:
+      retryCount: 3
+`
+	err := os.WriteFile(yamlFile, []byte(yamlContent), 0644)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		opts           Options
+		pollKey        string
+		nestedRetryKey string
+	}{
+		{
+			name: "snake_case only",
+			opts: Options{
+				Root:          "root.section",
+				SnakeCaseKeys: true,
+			},
+			pollKey:        "poll_interval",
+			nestedRetryKey: "nested_config_retry_count",
+		},
+		{
+			name: "snake_case with prefix",
+			opts: Options{
+				Root:          "root.section",
+				SnakeCaseKeys: true,
+				KeyPrefix:     "msa_",
+			},
+			pollKey:        "msa_poll_interval",
+			nestedRetryKey: "msa_nested_config_retry_count",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := New(yamlFile, tt.opts)
+			srcWithKeys, ok := src.(rigging.SourceWithKeys)
+			require.True(t, ok, "source does not implement rigging.SourceWithKeys")
+
+			data, originalKeys, err := srcWithKeys.LoadWithKeys(context.Background())
+			require.NoError(t, err)
+
+			assert.Equal(t, "5s", data[tt.pollKey])
+			assert.Equal(t, 3, data[tt.nestedRetryKey])
+			assert.Equal(t, "root.section.pollInterval", originalKeys[tt.pollKey])
+			assert.Equal(t, "root.section.nestedConfig.retryCount", originalKeys[tt.nestedRetryKey])
+		})
+	}
 }
 
 func TestFileSource_Load_RootErrors(t *testing.T) {
@@ -234,12 +295,18 @@ root:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			src := New(yamlFile, Options{Root: tt.root})
-			data, err := src.Load(context.Background())
-			require.Error(t, err)
-			assert.Nil(t, data)
-			assert.True(t, errors.Is(err, tt.wantErr))
-			assert.Contains(t, err.Error(), tt.root)
+			modes := []Options{
+				{Root: tt.root},
+				{Root: tt.root, SnakeCaseKeys: true, KeyPrefix: "msa_"},
+			}
+			for _, opts := range modes {
+				src := New(yamlFile, opts)
+				data, err := src.Load(context.Background())
+				require.Error(t, err)
+				assert.Nil(t, data)
+				assert.True(t, errors.Is(err, tt.wantErr))
+				assert.Contains(t, err.Error(), tt.root)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## What

Add an opt-in subtree key-shape adaptation path to `sourcefile` for flattened file keys:
- `sourcefile.Options.SnakeCaseKeys` rewrites flattened keys to underscore `snake_case`
- `sourcefile.Options.KeyPrefix` prepends an optional domain prefix to adapted keys
- adaptation is applied after `Root` resolution/flattening and is disabled by default

Also add focused `sourcefile` tests for:
- default behavior unchanged
- camelCase -> snake_case adaptation
- prefix injection
- nested key adaptation
- `LoadWithKeys` adapted key/original key consistency
- unchanged `Root` error behavior (`ErrRootNotFound`, `ErrRootNotMap`, `ErrInvalidRoot`)

Update docs in:
- `docs/configuration-sources.md`
- `docs/api-reference.md`

## Why

`sourcefile.Options.Root` correctly extracts subtrees, but camelCase subtree keys like `pollInterval` can mismatch common snake_case key conventions (for example `msa_poll_interval`) after normalization, forcing external key-mapping wrappers. This change provides a built-in, opt-in adaptation path while preserving default behavior.

## Type

- [ ] Fix
- [x] Feature
- [x] Docs
- [ ] Performance
- [ ] Breaking change

## Testing

```bash
# Commands you ran
gofmt -w sourcefile/file.go sourcefile/file_test.go
go test ./sourcefile

# Would run for full-repo verification
go test ./...
make ci
```