### PR TITLE
test: cover key adoptation colission

### DIFF
--- a/sourcefile/file.go
+++ b/sourcefile/file.go
@@ -119,7 +119,7 @@ func (f *fileSource) LoadWithKeys(ctx context.Context) (map[string]any, map[stri
 		}
 	}
 	if f.opts.SnakeCaseKeys || f.opts.KeyPrefix != "" {
-		adapted, adaptedOriginal, adaptErr := adaptFlattenedKeys(flattened, originalKeys, f.opts)
+		adapted, adaptedOriginal, adaptErr := adaptFlattenedKeys(flattened, originalKeys, f.opts, f.path)
 		if adaptErr != nil {
 			return nil, nil, adaptErr
 		}
@@ -130,7 +130,7 @@ func (f *fileSource) LoadWithKeys(ctx context.Context) (map[string]any, map[stri
 	return flattened, originalKeys, nil
 }
 
-func adaptFlattenedKeys(flattened map[string]any, originalKeys map[string]string, opts Options) (map[string]any, map[string]string, error) {
+func adaptFlattenedKeys(flattened map[string]any, originalKeys map[string]string, opts Options, sourcePath string) (map[string]any, map[string]string, error) {
 	adapted := make(map[string]any, len(flattened))
 	adaptedOriginalKeys := make(map[string]string, len(originalKeys))
 
@@ -146,7 +146,8 @@ func adaptFlattenedKeys(flattened map[string]any, originalKeys map[string]string
 				existingOriginal = adaptedKey
 			}
 			return nil, nil, fmt.Errorf(
-				"sourcefile: adapted key collision for %q (from %q and %q)",
+				"sourcefile: adapted key collision in %q for %q (from %q and %q)",
+				sourcePath,
 				adaptedKey,
 				existingOriginal,
 				currentOriginal,

--- a/sourcefile/file.go
+++ b/sourcefile/file.go
@@ -136,11 +136,24 @@ func adaptFlattenedKeys(flattened map[string]any, originalKeys map[string]string
 
 	for key, value := range flattened {
 		adaptedKey := adaptKeyShape(key, opts)
-		if _, exists := adapted[adaptedKey]; exists {
-			return nil, nil, fmt.Errorf("sourcefile: adapted key collision for %q", adaptedKey)
+		currentOriginal := originalKeys[key]
+		if currentOriginal == "" {
+			currentOriginal = key
+		}
+
+		if existingOriginal, exists := adaptedOriginalKeys[adaptedKey]; exists {
+			if existingOriginal == "" {
+				existingOriginal = adaptedKey
+			}
+			return nil, nil, fmt.Errorf(
+				"sourcefile: adapted key collision for %q (from %q and %q)",
+				adaptedKey,
+				existingOriginal,
+				currentOriginal,
+			)
 		}
 		adapted[adaptedKey] = value
-		adaptedOriginalKeys[adaptedKey] = originalKeys[key]
+		adaptedOriginalKeys[adaptedKey] = currentOriginal
 	}
 
 	return adapted, adaptedOriginalKeys, nil

--- a/sourcefile/file_test.go
+++ b/sourcefile/file_test.go
@@ -270,6 +270,34 @@ root:
 	}
 }
 
+func TestFileSource_Load_Root_KeyAdaptationCollision(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "config.yaml")
+	yamlContent := `
+root:
+  section:
+    apiKey: first
+    api_key: second
+`
+	err := os.WriteFile(yamlFile, []byte(yamlContent), 0644)
+	require.NoError(t, err)
+
+	src := New(yamlFile, Options{
+		Root:          "root.section",
+		SnakeCaseKeys: true,
+	})
+	srcWithKeys, ok := src.(rigging.SourceWithKeys)
+	require.True(t, ok, "source does not implement rigging.SourceWithKeys")
+
+	data, originalKeys, err := srcWithKeys.LoadWithKeys(context.Background())
+	require.Error(t, err)
+	assert.Nil(t, data)
+	assert.Nil(t, originalKeys)
+	assert.Contains(t, err.Error(), `sourcefile: adapted key collision for "api_key"`)
+	assert.Contains(t, err.Error(), "root.section.apiKey")
+	assert.Contains(t, err.Error(), "root.section.api_key")
+}
+
 func TestFileSource_Load_RootErrors(t *testing.T) {
 	tmpDir := t.TempDir()
 	yamlFile := filepath.Join(tmpDir, "config.yaml")

--- a/sourcefile/file_test.go
+++ b/sourcefile/file_test.go
@@ -293,7 +293,9 @@ root:
 	require.Error(t, err)
 	assert.Nil(t, data)
 	assert.Nil(t, originalKeys)
-	assert.Contains(t, err.Error(), `sourcefile: adapted key collision for "api_key"`)
+	assert.Contains(t, err.Error(), "sourcefile: adapted key collision in")
+	assert.Contains(t, err.Error(), `"api_key"`)
+	assert.Contains(t, err.Error(), yamlFile)
 	assert.Contains(t, err.Error(), "root.section.apiKey")
 	assert.Contains(t, err.Error(), "root.section.api_key")
 }


### PR DESCRIPTION
followup on https://github.com/Azhovan/rigging/pull/50/changes

## What

Improve `sourcefile` adapted-key collision diagnostics by including the config file path in the collision error, and tighten the collision regression test assertions.

## Why

A review comment identified that collision errors lacked enough context in multi-file setups. Including file path plus both colliding original keys makes failures directly actionable.

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] Performance
- [ ] Breaking change

## Testing

Validated formatting and behavior with:

```bash
gofmt -w sourcefile/file.go sourcefile/file_test.go
go test ./sourcefile
go test ./...
go vet ./...
