### PR TITLE
fix: reject unknown structured collection keys

### DIFF
--- a/binding.go
+++ b/binding.go
@@ -696,7 +696,15 @@ func tryBindNestedField(
 		if rawMap, ok := entry.value.(map[string]any); ok {
 			nestedData := make(map[string]mergedEntry)
 			for k, v := range rawMap {
-				nestedData[strings.ToLower(k)] = mergedEntry{value: v, sourceName: entry.sourceName}
+				normalizedKey := strings.ToLower(k)
+				if _, exists := nestedData[normalizedKey]; exists {
+					return true, []FieldError{{
+						FieldPath: fieldPath + "." + normalizedKey,
+						Code:      ErrCodeInvalidType,
+						Message:   "duplicate configuration keys after normalization",
+					}}
+				}
+				nestedData[normalizedKey] = mergedEntry{value: v, sourceName: entry.sourceName}
 			}
 			return true, bindNested(fieldValue, nestedData, "", fieldPath)
 		}

--- a/binding.go
+++ b/binding.go
@@ -696,7 +696,7 @@ func tryBindNestedField(
 		if rawMap, ok := entry.value.(map[string]any); ok {
 			nestedData := make(map[string]mergedEntry)
 			for k, v := range rawMap {
-				nestedData[k] = mergedEntry{value: v, sourceName: entry.sourceName}
+				nestedData[strings.ToLower(k)] = mergedEntry{value: v, sourceName: entry.sourceName}
 			}
 			return true, bindNested(fieldValue, nestedData, "", fieldPath)
 		}

--- a/loader.go
+++ b/loader.go
@@ -144,17 +144,23 @@ func (l *Loader[T]) loadInternal(ctx context.Context, store bool) (*T, *Provenan
 	// Step 3: In strict mode, detect unknown keys
 	if l.strict {
 		validKeys := collectValidKeys(rootType, "")
+		validKeyTypes := collectValidKeyTypes(rootType, "")
 		dynamicMapKeyPatterns := collectDynamicMapKeyPatterns(rootType, "")
 
 		// Check for unknown keys
 		var unknownKeyErrors []FieldError
-		for key := range mergedData {
+		for key, entry := range mergedData {
 			if !validKeys[key] && !matchesDynamicMapKeyPattern(key, dynamicMapKeyPatterns) {
 				unknownKeyErrors = append(unknownKeyErrors, FieldError{
 					FieldPath: key,
 					Code:      ErrCodeUnknownKey,
 					Message:   "unknown configuration key (strict mode)",
 				})
+				continue
+			}
+
+			if fieldType, ok := validKeyTypes[key]; ok {
+				unknownKeyErrors = append(unknownKeyErrors, collectStructuredUnknownKeyErrors(entry.value, fieldType, key)...)
 			}
 		}
 
@@ -305,6 +311,50 @@ func collectValidKeys(t reflect.Type, prefix string) map[string]bool {
 	return validKeys
 }
 
+func collectValidKeyTypes(t reflect.Type, prefix string) map[string]reflect.Type {
+	validKeyTypes := make(map[string]reflect.Type)
+
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return validKeyTypes
+	}
+
+	for _, meta := range getStructFieldMeta(t) {
+		field := meta.field
+		tagCfg := meta.tagCfg
+		keyPath := determineKeyPath(field.Name, tagCfg, prefix)
+		fieldType := field.Type
+
+		validKeyTypes[keyPath] = fieldType
+
+		if isOptionalType(fieldType) {
+			innerType := fieldType.Field(0).Type
+			if innerType.Kind() == reflect.Struct {
+				for nestedKey, nestedType := range collectValidKeyTypes(innerType, keyPath) {
+					validKeyTypes[nestedKey] = nestedType
+				}
+			}
+			continue
+		}
+
+		if fieldType.Kind() != reflect.Struct || fieldType.PkgPath() == "time" {
+			continue
+		}
+
+		nestedPrefix := keyPath
+		if tagCfg.prefix != "" {
+			nestedPrefix = tagCfg.prefix
+		}
+		for nestedKey, nestedType := range collectValidKeyTypes(fieldType, nestedPrefix) {
+			validKeyTypes[nestedKey] = nestedType
+		}
+	}
+
+	return validKeyTypes
+}
+
 func collectDynamicMapKeyPatterns(t reflect.Type, prefix string) []string {
 	patternSet := make(map[string]struct{})
 
@@ -362,6 +412,139 @@ func collectDynamicMapKeyPatterns(t reflect.Type, prefix string) []string {
 	}
 
 	return patterns
+}
+
+func collectStructuredUnknownKeyErrors(rawValue any, targetType reflect.Type, keyPath string) []FieldError {
+	if rawValue == nil {
+		return nil
+	}
+
+	targetType = unwrapStrictType(targetType)
+
+	switch targetType.Kind() {
+	case reflect.Struct:
+		if targetType == timeType || targetType == durationType {
+			return nil
+		}
+
+		rawMap, ok := rawStringMap(rawValue)
+		if !ok {
+			return nil
+		}
+
+		return collectUnknownStructMapKeys(rawMap, targetType, keyPath)
+
+	case reflect.Slice, reflect.Array:
+		elemType := unwrapStrictType(targetType.Elem())
+		if elemType.Kind() != reflect.Struct || elemType == timeType || elemType == durationType {
+			return nil
+		}
+
+		rawRef := reflect.ValueOf(rawValue)
+		if rawRef.Kind() != reflect.Slice && rawRef.Kind() != reflect.Array {
+			return nil
+		}
+
+		var fieldErrors []FieldError
+		for i := 0; i < rawRef.Len(); i++ {
+			elemMap, ok := rawStringMap(rawRef.Index(i).Interface())
+			if !ok {
+				continue
+			}
+
+			fieldErrors = append(fieldErrors, collectUnknownStructMapKeys(elemMap, elemType, fmt.Sprintf("%s.%d", keyPath, i))...)
+		}
+		return fieldErrors
+
+	case reflect.Map:
+		if targetType.Key().Kind() != reflect.String {
+			return nil
+		}
+
+		elemType := unwrapStrictType(targetType.Elem())
+		if elemType.Kind() != reflect.Struct || elemType == timeType || elemType == durationType {
+			return nil
+		}
+
+		rawMapRef := reflect.ValueOf(rawValue)
+		if rawMapRef.Kind() != reflect.Map {
+			return nil
+		}
+
+		var fieldErrors []FieldError
+		for _, rawKey := range rawMapRef.MapKeys() {
+			if rawKey.Kind() != reflect.String {
+				continue
+			}
+
+			elemMap, ok := rawStringMap(rawMapRef.MapIndex(rawKey).Interface())
+			if !ok {
+				continue
+			}
+
+			fieldErrors = append(fieldErrors, collectUnknownStructMapKeys(elemMap, elemType, keyPath+"."+rawKey.String())...)
+		}
+		return fieldErrors
+	}
+
+	return nil
+}
+
+func collectUnknownStructMapKeys(rawMap map[string]any, targetType reflect.Type, keyPath string) []FieldError {
+	validKeys := collectValidKeys(targetType, "")
+	validKeyTypes := collectValidKeyTypes(targetType, "")
+	dynamicMapKeyPatterns := collectDynamicMapKeyPatterns(targetType, "")
+
+	var fieldErrors []FieldError
+	for rawKey, rawValue := range rawMap {
+		normalizedKey := strings.ToLower(rawKey)
+		if !validKeys[normalizedKey] && !matchesDynamicMapKeyPattern(normalizedKey, dynamicMapKeyPatterns) {
+			fieldErrors = append(fieldErrors, FieldError{
+				FieldPath: keyPath + "." + normalizedKey,
+				Code:      ErrCodeUnknownKey,
+				Message:   "unknown configuration key (strict mode)",
+			})
+			continue
+		}
+
+		if nestedType, ok := validKeyTypes[normalizedKey]; ok {
+			fieldErrors = append(fieldErrors, collectStructuredUnknownKeyErrors(rawValue, nestedType, keyPath+"."+normalizedKey)...)
+		}
+	}
+
+	return fieldErrors
+}
+
+func unwrapStrictType(t reflect.Type) reflect.Type {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if isOptionalType(t) {
+		return unwrapStrictType(t.Field(0).Type)
+	}
+	return t
+}
+
+func rawStringMap(rawValue any) (map[string]any, bool) {
+	rawMap, ok := rawValue.(map[string]any)
+	if ok {
+		return rawMap, true
+	}
+
+	rawRef := reflect.ValueOf(rawValue)
+	if !rawRef.IsValid() || rawRef.Kind() != reflect.Map {
+		return nil, false
+	}
+
+	result := make(map[string]any, rawRef.Len())
+	for _, rawKey := range rawRef.MapKeys() {
+		if rawKey.Kind() != reflect.String {
+			return nil, false
+		}
+		result[rawKey.String()] = rawRef.MapIndex(rawKey).Interface()
+	}
+
+	return result, true
 }
 
 func collectMapValueKeyPatterns(baseKey string, valueType reflect.Type) []string {

--- a/loader.go
+++ b/loader.go
@@ -143,14 +143,13 @@ func (l *Loader[T]) loadInternal(ctx context.Context, store bool) (*T, *Provenan
 
 	// Step 3: In strict mode, detect unknown keys
 	if l.strict {
-		validKeys := collectValidKeys(rootType, "")
-		validKeyTypes := collectValidKeyTypes(rootType, "")
-		dynamicMapKeyPatterns := collectDynamicMapKeyPatterns(rootType, "")
+		strictMetadataCache := make(map[strictValidationMetadataKey]strictValidationMetadata)
+		strictMetadata := getStrictValidationMetadata(rootType, "", strictMetadataCache)
 
 		// Check for unknown keys
 		var unknownKeyErrors []FieldError
 		for key, entry := range mergedData {
-			if !validKeys[key] && !matchesDynamicMapKeyPattern(key, dynamicMapKeyPatterns) {
+			if !strictMetadata.validKeys[key] && !matchesDynamicMapKeyPattern(key, strictMetadata.dynamicMapKeyPatterns) {
 				unknownKeyErrors = append(unknownKeyErrors, FieldError{
 					FieldPath: key,
 					Code:      ErrCodeUnknownKey,
@@ -159,8 +158,8 @@ func (l *Loader[T]) loadInternal(ctx context.Context, store bool) (*T, *Provenan
 				continue
 			}
 
-			if fieldType, ok := validKeyTypes[key]; ok {
-				unknownKeyErrors = append(unknownKeyErrors, collectStructuredUnknownKeyErrors(entry.value, fieldType, key)...)
+			if fieldType, ok := strictMetadata.validKeyTypes[key]; ok {
+				unknownKeyErrors = append(unknownKeyErrors, collectStructuredUnknownKeyErrors(entry.value, fieldType, key, strictMetadataCache)...)
 			}
 		}
 
@@ -355,6 +354,43 @@ func collectValidKeyTypes(t reflect.Type, prefix string) map[string]reflect.Type
 	return validKeyTypes
 }
 
+type strictValidationMetadata struct {
+	validKeys             map[string]bool
+	validKeyTypes         map[string]reflect.Type
+	dynamicMapKeyPatterns []string
+}
+
+type strictValidationMetadataKey struct {
+	targetType reflect.Type
+	prefix     string
+}
+
+func getStrictValidationMetadata(
+	targetType reflect.Type,
+	prefix string,
+	cache map[strictValidationMetadataKey]strictValidationMetadata,
+) strictValidationMetadata {
+	for targetType.Kind() == reflect.Ptr {
+		targetType = targetType.Elem()
+	}
+
+	cacheKey := strictValidationMetadataKey{
+		targetType: targetType,
+		prefix:     prefix,
+	}
+	if metadata, ok := cache[cacheKey]; ok {
+		return metadata
+	}
+
+	metadata := strictValidationMetadata{
+		validKeys:             collectValidKeys(targetType, prefix),
+		validKeyTypes:         collectValidKeyTypes(targetType, prefix),
+		dynamicMapKeyPatterns: collectDynamicMapKeyPatterns(targetType, prefix),
+	}
+	cache[cacheKey] = metadata
+	return metadata
+}
+
 func collectDynamicMapKeyPatterns(t reflect.Type, prefix string) []string {
 	patternSet := make(map[string]struct{})
 
@@ -414,7 +450,12 @@ func collectDynamicMapKeyPatterns(t reflect.Type, prefix string) []string {
 	return patterns
 }
 
-func collectStructuredUnknownKeyErrors(rawValue any, targetType reflect.Type, keyPath string) []FieldError {
+func collectStructuredUnknownKeyErrors(
+	rawValue any,
+	targetType reflect.Type,
+	keyPath string,
+	metadataCache map[strictValidationMetadataKey]strictValidationMetadata,
+) []FieldError {
 	if rawValue == nil {
 		return nil
 	}
@@ -432,7 +473,7 @@ func collectStructuredUnknownKeyErrors(rawValue any, targetType reflect.Type, ke
 			return nil
 		}
 
-		return collectUnknownStructMapKeys(rawMap, targetType, keyPath)
+		return collectUnknownStructMapKeys(rawMap, targetType, keyPath, metadataCache)
 
 	case reflect.Slice, reflect.Array:
 		elemType := unwrapStrictType(targetType.Elem())
@@ -452,7 +493,7 @@ func collectStructuredUnknownKeyErrors(rawValue any, targetType reflect.Type, ke
 				continue
 			}
 
-			fieldErrors = append(fieldErrors, collectUnknownStructMapKeys(elemMap, elemType, fmt.Sprintf("%s.%d", keyPath, i))...)
+			fieldErrors = append(fieldErrors, collectUnknownStructMapKeys(elemMap, elemType, fmt.Sprintf("%s.%d", keyPath, i), metadataCache)...)
 		}
 		return fieldErrors
 
@@ -482,7 +523,7 @@ func collectStructuredUnknownKeyErrors(rawValue any, targetType reflect.Type, ke
 				continue
 			}
 
-			fieldErrors = append(fieldErrors, collectUnknownStructMapKeys(elemMap, elemType, keyPath+"."+rawKey.String())...)
+			fieldErrors = append(fieldErrors, collectUnknownStructMapKeys(elemMap, elemType, keyPath+"."+strings.ToLower(rawKey.String()), metadataCache)...)
 		}
 		return fieldErrors
 	}
@@ -490,15 +531,18 @@ func collectStructuredUnknownKeyErrors(rawValue any, targetType reflect.Type, ke
 	return nil
 }
 
-func collectUnknownStructMapKeys(rawMap map[string]any, targetType reflect.Type, keyPath string) []FieldError {
-	validKeys := collectValidKeys(targetType, "")
-	validKeyTypes := collectValidKeyTypes(targetType, "")
-	dynamicMapKeyPatterns := collectDynamicMapKeyPatterns(targetType, "")
+func collectUnknownStructMapKeys(
+	rawMap map[string]any,
+	targetType reflect.Type,
+	keyPath string,
+	metadataCache map[strictValidationMetadataKey]strictValidationMetadata,
+) []FieldError {
+	strictMetadata := getStrictValidationMetadata(targetType, "", metadataCache)
 
 	var fieldErrors []FieldError
 	for rawKey, rawValue := range rawMap {
 		normalizedKey := strings.ToLower(rawKey)
-		if !validKeys[normalizedKey] && !matchesDynamicMapKeyPattern(normalizedKey, dynamicMapKeyPatterns) {
+		if !strictMetadata.validKeys[normalizedKey] && !matchesDynamicMapKeyPattern(normalizedKey, strictMetadata.dynamicMapKeyPatterns) {
 			fieldErrors = append(fieldErrors, FieldError{
 				FieldPath: keyPath + "." + normalizedKey,
 				Code:      ErrCodeUnknownKey,
@@ -507,8 +551,8 @@ func collectUnknownStructMapKeys(rawMap map[string]any, targetType reflect.Type,
 			continue
 		}
 
-		if nestedType, ok := validKeyTypes[normalizedKey]; ok {
-			fieldErrors = append(fieldErrors, collectStructuredUnknownKeyErrors(rawValue, nestedType, keyPath+"."+normalizedKey)...)
+		if nestedType, ok := strictMetadata.validKeyTypes[normalizedKey]; ok {
+			fieldErrors = append(fieldErrors, collectStructuredUnknownKeyErrors(rawValue, nestedType, keyPath+"."+normalizedKey, metadataCache)...)
 		}
 	}
 

--- a/loader_test.go
+++ b/loader_test.go
@@ -1025,6 +1025,80 @@ func TestLoad_NestedCollections(t *testing.T) {
 		}
 	})
 
+	t.Run("strict mode rejects unknown nested key in direct map value", func(t *testing.T) {
+		source := &mockSource{
+			data: map[string]any{
+				"clickhouse_map": map[string]any{
+					"primary": map[string]any{
+						"host":    "ch1",
+						"port":    9000,
+						"unknown": "bad",
+					},
+				},
+			},
+		}
+
+		cfg, err := NewLoader[Config]().WithSource(source).Load(context.Background())
+		if err == nil {
+			t.Fatal("expected strict-mode error for unknown nested map value key")
+		}
+		if cfg != nil {
+			t.Fatal("expected nil cfg when strict-mode validation fails")
+		}
+
+		valErr, ok := err.(*ValidationError)
+		if !ok {
+			t.Fatalf("expected ValidationError, got %T", err)
+		}
+
+		foundUnknown := false
+		for _, fieldErr := range valErr.FieldErrors {
+			if fieldErr.Code == ErrCodeUnknownKey && fieldErr.FieldPath == "clickhouse_map.primary.unknown" {
+				foundUnknown = true
+			}
+		}
+		if !foundUnknown {
+			t.Fatalf("expected unknown_key for clickhouse_map.primary.unknown, got %#v", valErr.FieldErrors)
+		}
+	})
+
+	t.Run("strict mode rejects unknown nested key in slice element", func(t *testing.T) {
+		source := &mockSource{
+			data: map[string]any{
+				"clickhouse_list": []any{
+					map[string]any{
+						"host":    "ch1",
+						"port":    9000,
+						"unknown": "bad",
+					},
+				},
+			},
+		}
+
+		cfg, err := NewLoader[Config]().WithSource(source).Load(context.Background())
+		if err == nil {
+			t.Fatal("expected strict-mode error for unknown nested slice element key")
+		}
+		if cfg != nil {
+			t.Fatal("expected nil cfg when strict-mode validation fails")
+		}
+
+		valErr, ok := err.(*ValidationError)
+		if !ok {
+			t.Fatalf("expected ValidationError, got %T", err)
+		}
+
+		foundUnknown := false
+		for _, fieldErr := range valErr.FieldErrors {
+			if fieldErr.Code == ErrCodeUnknownKey && fieldErr.FieldPath == "clickhouse_list.0.unknown" {
+				foundUnknown = true
+			}
+		}
+		if !foundUnknown {
+			t.Fatalf("expected unknown_key for clickhouse_list.0.unknown, got %#v", valErr.FieldErrors)
+		}
+	})
+
 	t.Run("strict mode disabled ignores unknown nested key in flattened map value", func(t *testing.T) {
 		source := &mockSource{
 			data: map[string]any{

--- a/loader_test.go
+++ b/loader_test.go
@@ -941,6 +941,44 @@ func TestLoad_NestedStruct(t *testing.T) {
 			t.Errorf("expected Database.Port=5432, got %d", cfg.Database.Port)
 		}
 	})
+
+	t.Run("direct nested map rejects case collisions", func(t *testing.T) {
+		type ConfigWithDirectMap struct {
+			Database Database
+		}
+
+		source := &mockSource{
+			data: map[string]any{
+				"database": map[string]any{
+					"Host": "localhost",
+					"host": "db.example.com",
+				},
+			},
+		}
+
+		cfg, err := NewLoader[ConfigWithDirectMap]().WithSource(source).Load(context.Background())
+		if err == nil {
+			t.Fatal("expected error for colliding nested map keys")
+		}
+		if cfg != nil {
+			t.Fatal("expected nil cfg when nested key collision fails")
+		}
+
+		valErr, ok := err.(*ValidationError)
+		if !ok {
+			t.Fatalf("expected ValidationError, got %T", err)
+		}
+
+		foundCollision := false
+		for _, fieldErr := range valErr.FieldErrors {
+			if fieldErr.Code == ErrCodeInvalidType && fieldErr.FieldPath == "Database.host" {
+				foundCollision = true
+			}
+		}
+		if !foundCollision {
+			t.Fatalf("expected invalid_type for Database.host collision, got %#v", valErr.FieldErrors)
+		}
+	})
 }
 
 func TestLoad_NestedCollections(t *testing.T) {

--- a/loader_test.go
+++ b/loader_test.go
@@ -914,6 +914,33 @@ func TestLoad_NestedStruct(t *testing.T) {
 	if cfg.Database.Port != 5432 {
 		t.Errorf("expected Database.Port=5432, got %d", cfg.Database.Port)
 	}
+
+	t.Run("direct nested map normalizes inner keys like strict validation", func(t *testing.T) {
+		type ConfigWithDirectMap struct {
+			Database Database
+		}
+
+		source := &mockSource{
+			data: map[string]any{
+				"database": map[string]any{
+					"Host": "localhost",
+					"Port": 5432,
+				},
+			},
+		}
+
+		cfg, err := NewLoader[ConfigWithDirectMap]().WithSource(source).Load(context.Background())
+		if err != nil {
+			t.Fatalf("Load failed: %v", err)
+		}
+
+		if cfg.Database.Host != "localhost" {
+			t.Errorf("expected Database.Host=localhost, got %s", cfg.Database.Host)
+		}
+		if cfg.Database.Port != 5432 {
+			t.Errorf("expected Database.Port=5432, got %d", cfg.Database.Port)
+		}
+	})
 }
 
 func TestLoad_NestedCollections(t *testing.T) {


### PR DESCRIPTION
## Summary
- reject unknown nested keys inside direct structured map values in strict mode
- reject unknown nested keys inside structured slice elements in strict mode
- add regression coverage for both strict-mode bypasses

## Validation
- go test ./... -run TestLoad_NestedCollections -count=1
- make ci (format, vet, and tests passed; lint failed because local golangci-lint was built with Go 1.25 while the active Go toolchain includes Go 1.26 files requiring a newer linter build)